### PR TITLE
Add IPv6 clarification

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,3 +7,5 @@ To run the example use ``mvn exec:java``:
     $ mvn compile exec:java -Dhost=YOUR_CLUSTER_ID.REGION.aws.found.io -Dshield.user="username:password"
 
 Replace `YOUR_CLUSTER_ID` with your cluster id and `REGION` with the region the cluster is started in.
+
+_(Note: by default, if IPv4 and IPv6 are both enabled then it is undetermined which will be used. The system properties `-Dipv4=true|false` and `-Dipv6=true|false` can be used to turn them on/off explicitly. If they are enabled then the network/host should support routing to the Cloud endpoint, eg this is not the case within Docker containers by default)._

--- a/src/main/java/no/found/elasticsearch/example/TransportExample.java
+++ b/src/main/java/no/found/elasticsearch/example/TransportExample.java
@@ -38,7 +38,7 @@ import org.elasticsearch.shield.ShieldPlugin;
 public class TransportExample {
 
     public ESLogger logger = ESLoggerFactory.getLogger(getClass().getCanonicalName());
-    // Note: if enablng IPv6 then should ensure that your host and network can route it to the Cloud endpoint
+    // Note: If enabling IPv6, then you should ensure that your host and network can route it to the Cloud endpoint.
     // (eg Docker disables IPv6 routing by default) - see also the system property parsing code below.
     private boolean ip6Enabled = true;
     private boolean ip4Enabled = true;
@@ -55,7 +55,7 @@ public class TransportExample {
         String clusterName = System.getProperty("cluster", hostBasedClusterName);
 
         boolean enableSsl = Boolean.parseBoolean(System.getProperty("ssl", "true"));
-        // Note: if enablng IPv6 then should ensure that your host and network can route it to the Cloud endpoint
+        // Note: If enabling IPv6, then you should ensure that your host and network can route it to the Cloud endpoint.
         // (eg Docker disables IPv6 routing by default) - see also the initialization code at the top of this file.
         ip6Enabled = Boolean.parseBoolean(System.getProperty("ip6", "true"));
         ip4Enabled = Boolean.parseBoolean(System.getProperty("ip4", "true"));

--- a/src/main/java/no/found/elasticsearch/example/TransportExample.java
+++ b/src/main/java/no/found/elasticsearch/example/TransportExample.java
@@ -38,6 +38,8 @@ import org.elasticsearch.shield.ShieldPlugin;
 public class TransportExample {
 
     public ESLogger logger = ESLoggerFactory.getLogger(getClass().getCanonicalName());
+    // Note: if enablng IPv6 then should ensure that your host and network can route it to the Cloud endpoint
+    // (eg Docker disables IPv6 routing by default) - see also the system property parsing code below.
     private boolean ip6Enabled = true;
     private boolean ip4Enabled = true;
 
@@ -53,8 +55,10 @@ public class TransportExample {
         String clusterName = System.getProperty("cluster", hostBasedClusterName);
 
         boolean enableSsl = Boolean.parseBoolean(System.getProperty("ssl", "true"));
-        ip4Enabled = Boolean.parseBoolean(System.getProperty("ip4", "true"));
+        // Note: if enablng IPv6 then should ensure that your host and network can route it to the Cloud endpoint
+        // (eg Docker disables IPv6 routing by default) - see also the initialization code at the top of this file.
         ip6Enabled = Boolean.parseBoolean(System.getProperty("ip6", "true"));
+        ip4Enabled = Boolean.parseBoolean(System.getProperty("ip4", "true"));
 
         logger.info("Connecting to cluster: [{}] via [{}:{}] using ssl:[{}]", clusterName, host, port, enableSsl);
 


### PR DESCRIPTION
From the Discuss forum, a transport client was failing only when run from Docker, but the endpoint was provably routable from within the container. The problem ended up being that the client was picking IPv6, which is not routable by default. This isn't a huge problem, but worth documenting in the example code so future users are aware of this possibility.

Thanks to @benzo-elastic for actually working out the problem. @beiske @xuzha can I get review? I just added comments/a note to the readme.