### PR TITLE
Clarify that Shield is required

### DIFF
--- a/src/main/java/no/found/elasticsearch/example/TransportExample.java
+++ b/src/main/java/no/found/elasticsearch/example/TransportExample.java
@@ -74,7 +74,7 @@ public class TransportExample {
             .build();
 
         // Instantiate a TransportClient and add the cluster to the list of addresses to connect to.
-        // Only port 9343 (SSL-encrypted) is currently supported.
+        // Only port 9343 (SSL-encrypted) is currently supported. The use of Shield is required.
         TransportClient client = TransportClient.builder().addPlugin(ShieldPlugin.class).settings(settings).build();
         try {
             for (InetAddress address : InetAddress.getAllByName(host)) {


### PR DESCRIPTION
See https://discuss.elastic.co/t/shield-is-off-but-cant-connect-with-transport-client/65650/1. It doesn't hurt to be specific, as new users might try to take the easy route and not enable Shield ... only to fail because Shield is required.