### PR TITLE
Clarify that X-Pack security features are required

### DIFF
--- a/src/main/java/org/elasticsearch/cloud/transport/example/TransportExample.java
+++ b/src/main/java/org/elasticsearch/cloud/transport/example/TransportExample.java
@@ -74,7 +74,7 @@ public class TransportExample {
             .build();
 
         // Instantiate a TransportClient and add the cluster to the list of addresses to connect to.
-        // Only port 9343 (SSL-encrypted) is currently supported.
+        // Only port 9343 (SSL-encrypted) is currently supported. The use of X-Pack security features (formerly Shield) is required.
         TransportClient client = new PreBuiltXPackTransportClient(settings);
         try {
             for (InetAddress address : InetAddress.getAllByName(host)) {


### PR DESCRIPTION
Companion PR to https://github.com/elastic/found-shield-example/pull/5

Note that as per recent product naming guideline changes, we don't use "X-Pack Security" (some X-Pack docs might still be incorrect). We now say "X-Pack security features." :-)