### PR TITLE
Take quotes out of user/password arg

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -13,7 +13,7 @@
 
 To run the example use ``mvn exec:java``:
 
-    $ mvn compile exec:java -Dhost=YOUR_CLUSTER_ID.REGION.aws.found.io -Dxpack.security.user='username:password'
+    $ mvn compile exec:java -Dhost=YOUR_CLUSTER_ID.REGION.aws.found.io -Dxpack.security.user=username:password
 
 Replace `YOUR_CLUSTER_ID` with your cluster id and `REGION` with the region the cluster is started in.
 


### PR DESCRIPTION
The quotes probably work fine from a shell, but if you paste them into something like IntelliJ you get `'elastic` as the username.