### PR TITLE
Update transport client dependencies to 6.2.4

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,12 +1,13 @@
 # Elastic Cloud X-Pack Transport Example
 
-**Note:** This branch is intended for use with Elasticsearch 5.x, see the below table for earlier versions.
+**Note:** This branch is intended for use with Elasticsearch 6.x, see the below table for earlier versions.
 
-| Elasticsearch version  | Branch                                                                |
-|------------------------|-----------------------------------------------------------------------|
-| 5.x                    | [master](https://github.com/elastic/found-shield-example/tree/master) |
-| 2.x                    | [2.x](https://github.com/elastic/found-shield-example/tree/2.x)       |
-| 1.x                    | [1.x](https://github.com/elastic/found-shield-example/tree/1.x)       |
+| Elasticsearch version | Branch                                                                |
+|-----------------------|-----------------------------------------------------------------------|
+|                   6.x | [master](https://github.com/elastic/found-shield-example/tree/master) |
+|                   5.x | [5.x](https://github.com/elastic/found-shield-example/tree/5.x)       |
+|                   2.x | [2.x](https://github.com/elastic/found-shield-example/tree/2.x)       |
+|                   1.x | [1.x](https://github.com/elastic/found-shield-example/tree/1.x)       |
 
 
 ## Running

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <packaging>jar</packaging>
     <description>cloud-transport-example</description>
     <url>https://github.com/elastic/found-shield-example</url>
-    <version>5.1.1</version>
+    <version>6.2.4</version>
     <licenses>
         <license>
             <name>MIT</name>
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>x-pack-transport</artifactId>
-            <version>5.6.2</version>
+            <version>6.2.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/src/main/java/org/elasticsearch/cloud/transport/example/TransportExample.java
+++ b/src/main/java/org/elasticsearch/cloud/transport/example/TransportExample.java
@@ -26,7 +26,7 @@ import org.elasticsearch.client.Requests;
 import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.common.logging.ESLoggerFactory;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.transport.InetSocketTransportAddress;
+import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.xpack.client.PreBuiltXPackTransportClient;
 
 import java.net.Inet4Address;
@@ -78,13 +78,13 @@ public class TransportExample {
             .build();
 
         // Instantiate a TransportClient and add the cluster to the list of addresses to connect to.
-        // Only port 9343 (SSL-encrypted) is currently supported. The use of X-Pack security features (formerly Shield) is required.
+        // Only port 9343 (SSL-encrypted) is currently supported. The use of x-pack security features is required.
         TransportClient client = new PreBuiltXPackTransportClient(settings);
         try {
             for (InetAddress address : InetAddress.getAllByName(host)) {
                 if ((ip6Enabled && address instanceof Inet6Address)
                         || (ip4Enabled && address instanceof Inet4Address)) {
-                    client.addTransportAddress(new InetSocketTransportAddress(address, port));
+                    client.addTransportAddress(new TransportAddress(address, port));
                 }
             }
         } catch (UnknownHostException e) {


### PR DESCRIPTION
Closes https://github.com/elastic/cloud/issues/13958

Let's make master 6.x compatible