### PR TITLE
Specify Java version as 1.8 to fix compile error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,10 @@
     <description>cloud-transport-example</description>
     <url>https://github.com/elastic/found-shield-example</url>
     <version>6.2.4</version>
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
     <licenses>
         <license>
             <name>MIT</name>


### PR DESCRIPTION
Pulling down a fresh copy of this repo and running the example
command results in compilation errors about source option 5 and
target option 1.5 no longer being supported. Some digging around
online led me to find this issue: https://github.com/spring-guides/gs-maven/issues/21
where someone proposed a solution that fixed this.

Basically maven doesn't support 1.5 anymore and you have to
explicitly tell it which version to compile to. 

I picked Java 8 as it seemed like the most reasonable version but please let me know if you'd prefer something else (or if you have a preferred ordering for where properties goes in your pom file).

Here's a picture of the error for more information: 
![screen shot 2018-06-20 at 9 18 45 pm](https://user-images.githubusercontent.com/1187834/41697831-8f989ece-74cf-11e8-9b35-cc38d0e7457d.png)

After running the command again with these changes, I now get:
![screen shot 2018-06-20 at 9 19 43 pm](https://user-images.githubusercontent.com/1187834/41697845-b071b00e-74cf-11e8-880d-e91d8ad8bfa9.png)
