### PR TITLE
Updated 6.x note with compatibility warning.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # Elastic Cloud X-Pack Transport Example
 
-**Note:** This branch is intended for use with Elasticsearch 6.x, see the below table for earlier versions.
+**Note:** The Elasticsearch transport client is not supported at this point for accessing 6.0 Elasticsearch clusters managed by ECE. We are working on bringing back support for this, but we highly recommend for users to move to the [high level Java REST client](https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/java-rest-high.html).
 
 | Elasticsearch version | Branch                                                                |
 |-----------------------|-----------------------------------------------------------------------|

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # Elastic Cloud X-Pack Transport Example
 
-**Note:** The Elasticsearch transport client is not supported at this point for accessing 6.0 Elasticsearch clusters managed by ECE. We are working on bringing back support for this, but we highly recommend for users to move to the [high level Java REST client](https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/java-rest-high.html).
+**Note:** The Elasticsearch transport client is not supported at this point for accessing 6.0 Elasticsearch clusters managed by Elastic Cloud. We are working on bringing back support for this, but we highly recommend for users to move to the [high level Java REST client](https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/java-rest-high.html).
 
 | Elasticsearch version | Branch                                                                |
 |-----------------------|-----------------------------------------------------------------------|


### PR DESCRIPTION
After discussing the transport client usage with 6.x with @AlexP-Elastic, we realized it is not currently compatible with 6.x cloud clusters.  This PR updates the Readme file to reflect that.