### PR TITLE
Allow maven to package uberjar

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -19,6 +19,22 @@ To run the example use ``mvn exec:java``:
 Replace `YOUR_CLUSTER_ID` with your cluster id and `REGION` with the region the cluster is started in.
 
 
+## Package
+
+If you want to build an *uber-jar*, a package which contains the code and all of the dependencies, use the following command:
+
+```sh
+$ mvn compile assembly:single
+```
+
+The package will be build under `target/transport-example-VERSION-jar-with-dependencies.jar`.
+
+Then you can run it:
+
+```sh
+$ java -Dhost=YOUR_CLUSTER_ID.REGION.aws.found.io -Dxpack.security.user='username:password' -jar target/transport-example-VERSION-jar-with-dependencies.jar
+```
+
 ## IPv4 / IPv6
 
 By default, if IPv4 and IPv6 are both enabled then it is undetermined which will be used. The system properties `-Dip4=true|false` and `-Dip6=true|false` can be used to turn them on/off explicitly. If they are enabled then the network/host should support routing to the Cloud endpoint, e.g. this is not the case within Docker containers by default).

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,29 @@
                     <mainClass>org.elasticsearch.cloud.transport.example.TransportExample</mainClass>
                 </configuration>
             </plugin>
+            <!-- uberjar -->
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.1.1</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>org.elasticsearch.cloud.transport.example.TransportExample</mainClass>
+                        </manifest>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id> <!-- bind to the packaging phase -->
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
From the readme:

If you want to build an *uber-jar*, a package which contains the code and all of the dependencies, use the following command:

## Package

```sh
$ mvn compile assembly:single
```

The package will be build under `target/transport-example-VERSION-jar-with-dependencies.jar`.

Then you can run it:

```sh
$ java -Dhost=YOUR_CLUSTER_ID.REGION.aws.found.io -Dxpack.security.user='username:password' -jar target/transport-example-VERSION-jar-with-dependencies.jar
```